### PR TITLE
Allow Apple TV screensaver when playing KEXP

### DIFF
--- a/KexpTVStream/KexpTVStream/KexpNowPlayingVC.swift
+++ b/KexpTVStream/KexpTVStream/KexpNowPlayingVC.swift
@@ -74,12 +74,10 @@ class KexpNowPlayingVC: UIViewController, KexpAudioManagerDelegate, UITableViewD
     
     // MARK: - KexpAudioManagerDelegate Methods
     func kexpAudioPlayerDidStartPlaying() {
-        UIApplication.shared.isIdleTimerDisabled = true
         getNowPlayingInfo()
     }
     
     func kexpAudioPlayerDidStopPlaying(_ hardStop: Bool, backUpStream: Bool) {
-        UIApplication.shared.isIdleTimerDisabled = false
         setPlayMode(hardStop: hardStop, isBackUpStream: backUpStream)
     }
     


### PR DESCRIPTION
First off, thanks for this app. I use it all the time on my Apple TV to stream KEXP.

I like to stream KEXP, then let the Apple TV take over and display the cool city flyover screensaver. Currently, I need to open this app, start the stream, then press the remote to return to the homescreen. After 2 min the screensaver will then turn on.

If I *don't exit the app*, the KEXP Stream app prevents the screensaver from opening. It stays on the Now Playing screen instead.

Returning to the homescreen is kind of annoying, and often I forget. The screensaver never pops up.

[Apple says:](https://developer.apple.com/documentation/uikit/uiapplication/1623070-idletimerdisabled?language=objc)

 > Most apps should let the system turn off the screen when the idle timer elapses. **This includes audio apps.** With appropriate use of Audio Session Services, playback and recording proceed uninterrupted when the screen turns off. The only apps that should disable the idle timer are mapping apps, games, or programs where the app needs to continue displaying content when user interaction is minimal.

Allowing the screensaver to pop up will make this app more like the default Apple TV Music app, as well as match Apple's statement that audio apps should allow the screensaver.

Perhaps others feel differently, and you may want a setting for the option. Opening this initial PR to start the discussion.