### PR TITLE
Allow Apple TV screensaver when playing KEXP

### DIFF
--- a/KexpTVStream/KexpTVStream/KexpNowPlayingVC.swift
+++ b/KexpTVStream/KexpTVStream/KexpNowPlayingVC.swift
@@ -219,17 +219,14 @@ class KexpNowPlayingVC: UIViewController {
 
 extension KexpNowPlayingVC: AudioManagerDelegate {
     func audioPlayerDidStartPlaying() {
-        UIApplication.shared.isIdleTimerDisabled = true
         getNowPlayingInfo()
     }
     
     func audioPlayerDidStopPlaying(_ hardStop: Bool, backUpStream: Bool) {
-        UIApplication.shared.isIdleTimerDisabled = false
         setPlayMode(hardStop: hardStop, isBackUpStream: backUpStream)
     }
     
     func audioPlayerFailedToPlay() {
-        UIApplication.shared.isIdleTimerDisabled = false
         showAlert("The KEXP stream is down, please contact KEXP if the issue persists.")
     }
 }


### PR DESCRIPTION
This is a recommit of the changes from 5b1a2e and PR #5 that were then undone in 30f933.

Fixes #13

[Apple says](https://developer.apple.com/documentation/uikit/uiapplication/1623070-isidletimerdisabled):

 > Most apps should let the system turn off the screen when the idle timer elapses. This includes audio apps.
