### PR TITLE
Change wording of control for Idle Timer / Screen Saver

### DIFF
--- a/KexpTVStream/KexpTVStream/Source/UI/Sections/SettingsViewController.swift
+++ b/KexpTVStream/KexpTVStream/Source/UI/Sections/SettingsViewController.swift
@@ -22,8 +22,8 @@ class SettingsViewController: BaseViewController {
         let segmentedControl = UISegmentedControl()
         let font: [NSAttributedString.Key : Any] = [NSAttributedString.Key.font: ThemeManager.Settings.font as Any]
         segmentedControl.setTitleTextAttributes(font, for: .normal)
-        segmentedControl.insertSegment(withTitle: "Disabled", at: 0, animated: true)
-        segmentedControl.insertSegment(withTitle: "Enabled", at: 1, animated: true)
+        segmentedControl.insertSegment(withTitle: "Enabled", at: 0, animated: true)
+        segmentedControl.insertSegment(withTitle: "Disabled", at: 1, animated: true)
         segmentedControl.addTarget(self, action: #selector(idleTimerControlDidChange(_:)), for: .valueChanged)
         return segmentedControl
     }()
@@ -36,7 +36,7 @@ class SettingsViewController: BaseViewController {
 
         view.backgroundColor = .white
         
-        idleTimerSegmentedControl.selectedSegmentIndex = UserSettingsManager.disableTimer == true ? 0 : 1
+        idleTimerSegmentedControl.selectedSegmentIndex = UserSettingsManager.disableTimer ? 1 : 0
     }
     
     override func constructSubviews() {
@@ -55,7 +55,7 @@ class SettingsViewController: BaseViewController {
     }
     
     @objc private func idleTimerControlDidChange(_ sender: Any) {
-        let isIdleTimerDisabled = idleTimerSegmentedControl.selectedSegmentIndex == 0
+        let isIdleTimerDisabled = idleTimerSegmentedControl.selectedSegmentIndex == 1
         AnalyticsManager.fire(.disableIdleTimer(isIdleTimerDisabled))
         
         UserSettingsManager.disableTimer = isIdleTimerDisabled

--- a/KexpTVStream/KexpTVStream/Source/UI/Sections/SettingsViewController.swift
+++ b/KexpTVStream/KexpTVStream/Source/UI/Sections/SettingsViewController.swift
@@ -55,11 +55,11 @@ class SettingsViewController: BaseViewController {
     }
     
     @objc private func idleTimerControlDidChange(_ sender: Any) {
-        let isDisplayTimerIdle = idleTimerSegmentedControl.selectedSegmentIndex == 0 ? true : false
-        AnalyticsManager.fire(.disableIdleTimer(isDisplayTimerIdle))
+        let isIdleTimerDisabled = idleTimerSegmentedControl.selectedSegmentIndex == 0
+        AnalyticsManager.fire(.disableIdleTimer(isIdleTimerDisabled))
         
-        UserSettingsManager.disableTimer = isDisplayTimerIdle
-        UIApplication.shared.isIdleTimerDisabled = isDisplayTimerIdle
+        UserSettingsManager.disableTimer = isIdleTimerDisabled
+        UIApplication.shared.isIdleTimerDisabled = isIdleTimerDisabled
     }
 }
 

--- a/KexpTVStream/KexpTVStream/Source/UI/Sections/SettingsViewController.swift
+++ b/KexpTVStream/KexpTVStream/Source/UI/Sections/SettingsViewController.swift
@@ -47,14 +47,14 @@ class SettingsViewController: BaseViewController {
         contentStackView.addArrangedSubview(SettingsRowView(title: "Donate at kexp.org/donate"))
     }
     
-     override func constructConstraints() {
+    override func constructConstraints() {
         view.addSubview(contentStackView, constraints: [
             contentStackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             contentStackView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
     }
     
-   @objc private func idleTimerControlDidChange(_ sender: Any) {
+    @objc private func idleTimerControlDidChange(_ sender: Any) {
         let isDisplayTimerIdle = idleTimerSegmentedControl.selectedSegmentIndex == 0 ? true : false
         AnalyticsManager.fire(.disableIdleTimer(isDisplayTimerIdle))
         

--- a/KexpTVStream/KexpTVStream/Source/UI/Sections/SettingsViewController.swift
+++ b/KexpTVStream/KexpTVStream/Source/UI/Sections/SettingsViewController.swift
@@ -22,8 +22,8 @@ class SettingsViewController: BaseViewController {
         let segmentedControl = UISegmentedControl()
         let font: [NSAttributedString.Key : Any] = [NSAttributedString.Key.font: ThemeManager.Settings.font as Any]
         segmentedControl.setTitleTextAttributes(font, for: .normal)
-        segmentedControl.insertSegment(withTitle: "Yes", at: 0, animated: true)
-        segmentedControl.insertSegment(withTitle: "No", at: 1, animated: true)
+        segmentedControl.insertSegment(withTitle: "Disabled", at: 0, animated: true)
+        segmentedControl.insertSegment(withTitle: "Enabled", at: 1, animated: true)
         segmentedControl.addTarget(self, action: #selector(doneAction(_:)), for: .valueChanged)
         return segmentedControl
     }()
@@ -40,7 +40,7 @@ class SettingsViewController: BaseViewController {
     }
     
     override func constructSubviews() {
-        contentStackView.addArrangedSubview(SettingsRowView(title: "Disable Idle Timer:", view: disableIdleTimerSegmentedControl))
+        contentStackView.addArrangedSubview(SettingsRowView(title: "Idle Timer:", view: disableIdleTimerSegmentedControl))
         contentStackView.addArrangedSubview(SettingsRowView(title: "Version:", value: appVersion))
         contentStackView.addArrangedSubview(SettingsRowView(title: "Build:", value: appBuild))
         contentStackView.addArrangedSubview(SettingsRowView(title: "App Feedback: feedback@kexp.org"))

--- a/KexpTVStream/KexpTVStream/Source/UI/Sections/SettingsViewController.swift
+++ b/KexpTVStream/KexpTVStream/Source/UI/Sections/SettingsViewController.swift
@@ -18,13 +18,13 @@ class SettingsViewController: BaseViewController {
         return stackView
     }()
     
-    private lazy var disableIdleTimerSegmentedControl: UISegmentedControl = {
+    private lazy var idleTimerSegmentedControl: UISegmentedControl = {
         let segmentedControl = UISegmentedControl()
         let font: [NSAttributedString.Key : Any] = [NSAttributedString.Key.font: ThemeManager.Settings.font as Any]
         segmentedControl.setTitleTextAttributes(font, for: .normal)
         segmentedControl.insertSegment(withTitle: "Disabled", at: 0, animated: true)
         segmentedControl.insertSegment(withTitle: "Enabled", at: 1, animated: true)
-        segmentedControl.addTarget(self, action: #selector(doneAction(_:)), for: .valueChanged)
+        segmentedControl.addTarget(self, action: #selector(idleTimerControlDidChange(_:)), for: .valueChanged)
         return segmentedControl
     }()
     
@@ -36,7 +36,7 @@ class SettingsViewController: BaseViewController {
 
         view.backgroundColor = .white
         
-        disableIdleTimerSegmentedControl.selectedSegmentIndex = UserSettingsManager.disableTimer == true ? 0 : 1
+        idleTimerSegmentedControl.selectedSegmentIndex = UserSettingsManager.disableTimer == true ? 0 : 1
     }
     
     override func constructSubviews() {
@@ -54,8 +54,8 @@ class SettingsViewController: BaseViewController {
         ])
     }
     
-   @objc private func doneAction(_ sender: Any) {
-        let isDisplayTimerIdle = disableIdleTimerSegmentedControl.selectedSegmentIndex == 0 ? true : false
+   @objc private func idleTimerControlDidChange(_ sender: Any) {
+        let isDisplayTimerIdle = idleTimerSegmentedControl.selectedSegmentIndex == 0 ? true : false
         AnalyticsManager.fire(.disableIdleTimer(isDisplayTimerIdle))
         
         UserSettingsManager.disableTimer = isDisplayTimerIdle


### PR DESCRIPTION
Yesterday I noticed my Apple TV playing KEXP without a screensaver, which is very bad for my Plasma TV.

I went to go change the setting but was initially confused by the control, and in fact turned the screensaver off again.

This PR makes the idle timer preference behavior more intuitive:

 - Changes the default value, `"idle timer ON"`, to be first in the segmented control.
 - Changes Idle Timer control text:
   - was: `Disable Idle Timer: | Yes | No |`
   - now: `Idle Timer: | Enabled | Disabled |`

This change matches the Apple HIG for Segmented Controls:

 > Use short, meaningful nouns as segment titles. A segment’s **title clearly identifies the type of content** to expect when the segment is selected. In general, titles should be nouns (such as Library or Playlists).  
 > https://developer.apple.com/design/human-interface-guidelines/tvos/interface-elements/segmented-controls/

   
